### PR TITLE
fix(props): Fix Save/Restore scaling

### DIFF
--- a/sp/src/game/server/props.cpp
+++ b/sp/src/game/server/props.cpp
@@ -48,6 +48,7 @@
 #include "collisionutils.h"
 #include "vstdlib/IKeyValuesSystem.h" // From Alien Swarm SDK
 #endif
+#include "physics_saverestore.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -7237,6 +7238,7 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 
 	pInstance->VPhysicsDestroyObject();
 	pInstance->VPhysicsSetObject( pNewObject );
+    g_pPhysSaveRestoreManager->AssociateModel( pNewObject, pInstance->GetModelIndex() );
 
 	// Increase our model bounds
 	const model_t *pModel = modelinfo->GetModel( pInstance->GetModelIndex() );


### PR DESCRIPTION
This pull request introduces improvements to the handling of physics objects in the server-side code for props. The main change is the association of newly created physics objects with their corresponding model indices, which helps with save/restore functionality and potentially improves the consistency of physics behavior after scaling.

Physics save/restore improvements:

* Added an include for `physics_saverestore.h` to ensure access to the save/restore manager functionality.
* After creating a new physics object in `UTIL_CreateScaledPhysObject`, the code now calls `g_pPhysSaveRestoreManager->AssociateModel` to associate the new object with the model index of the instance.