### PR TITLE
Fix SetSpeed input type and conveyor speed initialization

### DIFF
--- a/sp/src/game/server/bmodels.cpp
+++ b/sp/src/game/server/bmodels.cpp
@@ -285,7 +285,7 @@ LINK_ENTITY_TO_CLASS( func_conveyor, CFuncConveyor );
 BEGIN_DATADESC( CFuncConveyor )
 
 	DEFINE_INPUTFUNC( FIELD_VOID, "ToggleDirection", InputToggleDirection ),
-	DEFINE_INPUTFUNC( FIELD_VOID, "SetSpeed", InputSetSpeed ),
+	DEFINE_INPUTFUNC( FIELD_FLOAT, "SetSpeed", InputSetSpeed ),
 
 	DEFINE_KEYFIELD( m_vecMoveDir, FIELD_VECTOR, "movedir" ),
 	DEFINE_FIELD( m_flConveyorSpeed, FIELD_FLOAT ),
@@ -320,8 +320,13 @@ void CFuncConveyor::Spawn( void )
 		AddSolidFlags( FSOLID_NOT_SOLID );
 	}
 
-	if ( m_flSpeed == 0 )
-		m_flSpeed = 100;
+    if ( !HasSpawnFlags( SF_CONVEYOR_VISUAL ) )
+    {
+        if ( m_flSpeed == 0 )
+        {
+            m_flSpeed = 100;
+        }
+    }
 
 	UpdateSpeed( m_flSpeed );
 }


### PR DESCRIPTION
This pull request makes improvements to the `CFuncConveyor` entity in `bmodels.cpp`, focusing on correcting input handling and ensuring proper default speed initialization. The main changes are:

**Input Handling Improvements:**

* Changed the `SetSpeed` input definition to accept a `FIELD_FLOAT` parameter instead of `FIELD_VOID`, allowing the conveyor's speed to be set dynamically via input.

**Default Speed Initialization:**

* Updated the `Spawn` method to set `m_flSpeed` to 100 if it is zero and the conveyor does not have the `SF_CONVEYOR_VISUAL` spawn flag, ensuring conveyors have a sensible default speed unless visually-only.