### PR TITLE
Add jump parameter overrides to CAI_BaseNPC

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -12182,6 +12182,10 @@ BEGIN_DATADESC( CAI_BaseNPC )
 
 	DEFINE_KEYFIELD( m_flSpeedModifier, FIELD_FLOAT, "BaseSpeedModifier" ),
 	DEFINE_FIELD( m_FakeSequenceGestureLayer,	FIELD_INTEGER ),
+
+    DEFINE_KEYFIELD( m_jumpUpOverride, FIELD_FLOAT, "JumpUpOverride" ),
+    DEFINE_KEYFIELD( m_jumpDownOverride, FIELD_FLOAT, "JumpDownOverride" ),
+    DEFINE_KEYFIELD( m_jumpDistOverride, FIELD_FLOAT, "JumpDistOverride" ),
 #endif
 
 	// Satisfy classcheck
@@ -12291,6 +12295,10 @@ BEGIN_DATADESC( CAI_BaseNPC )
 
 	DEFINE_OUTPUT( m_OnStateChange,	"OnStateChange" ),
 #endif
+
+    DEFINE_INPUTFUNC( FIELD_FLOAT, "SetMaxJumpUp", InputSetJumpUp ),
+    DEFINE_INPUTFUNC( FIELD_FLOAT, "SetMaxJumpDown", InputSetJumpDown ),
+    DEFINE_INPUTFUNC( FIELD_FLOAT, "SetMaxJumpDist", InputSetJumpDist ),
 
 	// Function pointers
 	DEFINE_USEFUNC( NPCUse ),
@@ -16741,4 +16749,19 @@ void CAI_BaseNPC::DesireCrouch( void )
 bool CAI_BaseNPC::IsInChoreo() const
 {
 	return m_bInChoreo;
+}
+
+void CAI_BaseNPC::InputSetJumpUp( inputdata_t& inputdata )
+{
+    m_jumpUpOverride = inputdata.value.Float();
+}
+
+void CAI_BaseNPC::InputSetJumpDown( inputdata_t& inputdata )
+{
+    m_jumpDownOverride = inputdata.value.Float();
+}
+
+void CAI_BaseNPC::InputSetJumpDist( inputdata_t& inputdata )
+{
+    m_jumpDistOverride = inputdata.value.Float();
 }

--- a/sp/src/game/server/ai_basenpc.h
+++ b/sp/src/game/server/ai_basenpc.h
@@ -2095,6 +2095,10 @@ public:
 	void InputIgnoreDangerSounds( inputdata_t &inputdata );
 	void InputUpdateEnemyMemory( inputdata_t &inputdata );
 
+    void InputSetJumpUp( inputdata_t& inputdata );
+    void InputSetJumpDown( inputdata_t& inputdata );
+    void InputSetJumpDist( inputdata_t& inputdata );
+
 	//---------------------------------
 	
 	virtual void		NotifyDeadFriend( CBaseEntity *pFriend ) { return; }
@@ -2443,6 +2447,10 @@ public:
 	void				GetPlayerAvoidBounds( Vector *pMins, Vector *pMaxs );
 
 	void				StartPingEffect( void ) { m_flTimePingEffect = gpGlobals->curtime + 2.0f; DispatchUpdateTransmitState(); }
+protected: // Jump override variables
+    float				m_jumpUpOverride = 0.0f;
+    float				m_jumpDownOverride = 0.0f;
+    float				m_jumpDistOverride = 0.0f;
 };
 
 

--- a/sp/src/game/server/ai_basenpc_movement.cpp
+++ b/sp/src/game/server/ai_basenpc_movement.cpp
@@ -297,16 +297,20 @@ bool CAI_BaseNPC::CanStandOn( CBaseEntity *pSurface ) const
 bool CAI_BaseNPC::IsJumpLegal( const Vector &startPos, const Vector &apex, const Vector &endPos, 
 							   float maxUp, float maxDown, float maxDist ) const
 {
-	if ((endPos.z - startPos.z) > maxUp + 0.1) 
+    float localMaxUp = m_jumpUpOverride > 0.0 ? m_jumpUpOverride : maxUp;
+    float localMaxDown = m_jumpDownOverride > 0.0 ? m_jumpDownOverride : maxDown;
+    float localMaxDist = m_jumpDistOverride > 0.0 ? m_jumpDistOverride : maxDist;
+
+	if ((endPos.z - startPos.z) > localMaxUp + 0.1)
 		return false;
-	if ((startPos.z - endPos.z) > maxDown + 0.1) 
+	if ((startPos.z - endPos.z) > localMaxDown + 0.1)
 		return false;
 
-	if ((apex.z - startPos.z) > maxUp * 1.25 ) 
+	if ((apex.z - startPos.z) > localMaxUp * 1.25 )
 		return false;
 
 	float dist = (startPos - endPos).Length();
-	if ( dist > maxDist + 0.1) 
+	if ( dist > localMaxDist + 0.1)
 		return false;
 	return true;
 }

--- a/sp/src/game/server/hl2/npc_monk.cpp
+++ b/sp/src/game/server/hl2/npc_monk.cpp
@@ -744,7 +744,7 @@ int CNPC_Monk::SelectFailSchedule( int failedSchedule, int failedTask, AI_TaskFa
 //-----------------------------------------------------------------------------
 bool CNPC_Monk::IsJumpLegal( const Vector &startPos, const Vector &apex, const Vector &endPos ) const
 {
-	if ( startPos.z - endPos.z < 0 )
+    if ( startPos.z - endPos.z < 0 && m_jumpUpOverride < 0 )
 		return false;
 	return BaseClass::IsJumpLegal( startPos, apex, endPos );
 }


### PR DESCRIPTION
This pull request adds support for dynamically overriding NPC jump parameters (jump up, jump down, and jump distance) in the AI system. It introduces new member variables, input functions, and data descriptors to allow these jump parameters to be set at runtime, and modifies the jump legality checks to use these overrides when present.

**Jump Parameter Override System:**

* Added new member variables (`m_jumpUpOverride`, `m_jumpDownOverride`, `m_jumpDistOverride`) to `CAI_BaseNPC` to store per-NPC jump parameter overrides, with initialization and data descriptors for save/load support. [[1]](diffhunk://#diff-3b2a79ae0e62aff9d87d4c3939593ee8d3b6bc7d87f04cbfe3070970e060b11bR2450-R2453) [[2]](diffhunk://#diff-cd5b21d3a5990b1d3f889bc4826128e783a25114405e119f1fe213b0ee7a605dR12185-R12188)
* Implemented new input functions (`InputSetJumpUp`, `InputSetJumpDown`, `InputSetJumpDist`) to allow these overrides to be set via entity inputs, and registered them in the data description. [[1]](diffhunk://#diff-3b2a79ae0e62aff9d87d4c3939593ee8d3b6bc7d87f04cbfe3070970e060b11bR2098-R2101) [[2]](diffhunk://#diff-cd5b21d3a5990b1d3f889bc4826128e783a25114405e119f1fe213b0ee7a605dR12299-R12302) [[3]](diffhunk://#diff-cd5b21d3a5990b1d3f889bc4826128e783a25114405e119f1fe213b0ee7a605dR16753-R16767)

**Jump Legality Logic Updates:**

* Updated `CAI_BaseNPC::IsJumpLegal` to use the override values if set, falling back to the original parameters otherwise.
* Modified `CNPC_Monk::IsJumpLegal` to account for the new `m_jumpUpOverride` variable when determining if a jump is legal.