### PR TITLE
Add flipping behavior for headcrab NPCs

### DIFF
--- a/sp/src/game/server/hl2/npc_headcrab.h
+++ b/sp/src/game/server/hl2/npc_headcrab.h
@@ -158,6 +158,8 @@ protected:
 #ifdef MAPBASE
 	COutputEvent m_OnLeap;
 #endif
+private:
+    inline bool	IsFlipped( void );
 };
 
 


### PR DESCRIPTION
Introduced a new flipping mechanic for headcrab NPCs, including:
- Added `SCHED_HEADCRAB_FLIP` schedule and `COND_HEADCRAB_FLIPPED` condition.
- Declared `ACT_HEADCRAB_FLIP` activity for the flipping animation.
- Updated `CBaseHeadcrab::SelectSchedule` to handle flipping logic.
- Modified `CBaseHeadcrab::TraceAttack` to trigger flipping in episodic mode.
- Added `CBaseHeadcrab::IsFlipped` to check flipping state.
- Updated `AI_BEGIN_CUSTOM_NPC` to define the new condition and schedule.
- Added save/restore support for flipping state in `CFastHeadcrab`.

These changes enable headcrabs to respond to specific conditions (e.g., being flipped over) with a new animation and behavior, enhancing their interactivity and realism.

(Describe your PR here and then fill out the checklist at the bottom)

---

#### Does this PR close any issues?
* (Optional) Insert issue number(s) and any related info here

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [ ] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [ ] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
